### PR TITLE
[Fix] Updated global name not being passed to `UserUpdated` event

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
@@ -8,12 +8,19 @@ namespace Discord.WebSocket
     [DebuggerDisplay(@"{DebuggerDisplay,nq}")]
     internal class SocketGlobalUser : SocketUser
     {
+        /// <inheritdoc/>
         public override bool IsBot { get; internal set; }
+        /// <inheritdoc/>
         public override string Username { get; internal set; }
+        /// <inheritdoc/>
         public override ushort DiscriminatorValue { get; internal set; }
+        /// <inheritdoc/>
         public override string? AvatarId { get; internal set; }
+        /// <inheritdoc/>
+        public override string? GlobalName { get { return GlobalUser.GlobalName; } internal set { GlobalUser.GlobalName = value; } }
         internal override SocketPresence? Presence { get; set; }
 
+        /// <inheritdoc/>
         public override bool IsWebhook => false;
         internal override SocketGlobalUser GlobalUser { get => this; set => throw new NotImplementedException(); }
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
@@ -30,6 +30,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override string? AvatarId { get { return GlobalUser.AvatarId; } internal set { GlobalUser.AvatarId = value; } }
         /// <inheritdoc />
+        public override string? GlobalName { get { return GlobalUser.GlobalName; } internal set { GlobalUser.GlobalName = value; } }
+        /// <inheritdoc />
         internal override SocketPresence? Presence { get { return GlobalUser.Presence; } set { GlobalUser.Presence = value; } }
 
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -47,6 +47,8 @@ namespace Discord.WebSocket
         public override ushort DiscriminatorValue { get { return GlobalUser.DiscriminatorValue; } internal set { GlobalUser.DiscriminatorValue = value; } }
         /// <inheritdoc />
         public override string? AvatarId { get { return GlobalUser.AvatarId; } internal set { GlobalUser.AvatarId = value; } }
+        /// <inheritdoc />
+        public override string? GlobalName { get { return GlobalUser.GlobalName; } internal set { GlobalUser.GlobalName = value; } }
 
         /// <inheritdoc />
         public GuildPermissions GuildPermissions => new GuildPermissions(Permissions.ResolveGuild(Guild, this));

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
@@ -29,6 +29,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override string? AvatarId { get { return GlobalUser.AvatarId; } internal set { GlobalUser.AvatarId = value; } }
         /// <inheritdoc />
+        public override string? GlobalName { get { return GlobalUser.GlobalName; } internal set { GlobalUser.GlobalName = value; } }
+        /// <inheritdoc />
         internal override SocketPresence? Presence { get { return GlobalUser.Presence; } set { GlobalUser.Presence = value; } }
         /// <inheritdoc />
         public UserProperties Flags { get; internal set; }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -78,6 +78,12 @@ namespace Discord.WebSocket
                 GuildUser.AvatarId = value;
             }
         }
+        /// <inheritdoc />
+        public override string? GlobalName
+        {
+            get => GlobalUser.GlobalName;
+            internal set => GlobalUser.GlobalName = value;
+        }
         /// <inheritdoc/>
         public string? DisplayAvatarId => GuildAvatarId ?? AvatarId;
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
@@ -19,6 +19,8 @@ namespace Discord.WebSocket
         public override ushort DiscriminatorValue { get; internal set; }
         /// <inheritdoc />
         public override string? AvatarId { get; internal set; }
+        /// <inheritdoc />
+        public override string? GlobalName { get; internal set; }
 
         /// <inheritdoc />
         public override bool IsBot { get; internal set; }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -34,7 +34,7 @@ namespace Discord.WebSocket
         internal abstract SocketPresence? Presence { get; set; }
 
         /// <inheritdoc />
-        public string? GlobalName { get; internal set; }
+        public abstract string? GlobalName { get; internal set; }
         /// <inheritdoc />
         public string? Pronouns { get; internal set; }
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketWebhookUser.cs
@@ -25,6 +25,8 @@ namespace Discord.WebSocket
         public override ushort DiscriminatorValue { get; internal set; }
         /// <inheritdoc />
         public override string? AvatarId { get; internal set; }
+        /// <inheritdoc />
+        public override string? GlobalName { get; internal set; }
 
 
         /// <inheritdoc />


### PR DESCRIPTION
Mirror of https://github.com/discord-net/Discord.Net/pull/2726

### Changes
- make `SocketXUser.GlobalName` return the global name of a `GlobalUser`