### PR TITLE
[Feature] New `ModifyCurrentApplication` features

### DIFF
--- a/src/Discord.Net.Core/DiscordConfig.cs
+++ b/src/Discord.Net.Core/DiscordConfig.cs
@@ -232,5 +232,10 @@ namespace Discord
         ///     Returns the max length of an application description.
         /// </summary>
         public const int MaxApplicationDescriptionLength = 400;
+
+        /// <summary>
+        ///     Returns the max amount of tags applied to an application.
+        /// </summary>
+        public const int MaxApplicationTagCount = 5;
     }
 }

--- a/src/Discord.Net.Core/Entities/Applications/ApplicationFlags.cs
+++ b/src/Discord.Net.Core/Entities/Applications/ApplicationFlags.cs
@@ -1,36 +1,65 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord;
 
 /// <summary>
 ///     Represents public flags for an application.
 /// </summary>
+[Flags]
 public enum ApplicationFlags
 {
+    /// <summary>
+    ///     Indicates if an app uses the Auto Moderation API.
+    /// </summary>
     UsesAutoModApi = 1 << 6,
 
+    /// <summary>
+    ///     Indicates that the app has been verified to use GUILD_PRESENCES intent.
+    /// </summary>
     GatewayPresence = 1 << 12,
 
+    /// <summary>
+    ///     Indicates that the app has enabled the GUILD_PRESENCES intent on a bot in less than 100 servers.
+    /// </summary>
     GatewayPresenceLimited = 1 << 13,
 
+    /// <summary>
+    ///     Indicates that the app has been verified to use GUILD_MEMBERS intent.
+    /// </summary>
     GatewayGuildMembers = 1 << 14,
 
+    /// <summary>
+    ///     Indicates that the app has enabled the GUILD_MEMBERS intent on a bot in less than 100 servers.
+    /// </summary>
     GatewayGuildMembersLimited = 1 << 15,
 
+    /// <summary>
+    ///     Indicates unusual growth of an app that prevents verification.
+    /// </summary>
     VerificationPendingGuildLimit = 1 << 16,
 
+    /// <summary>
+    ///     Indicates if an app is embedded within the Discord client.
+    /// </summary>
     Embedded = 1 << 17,
 
+    /// <summary>
+    ///     Indicates that the app has been verified to use MESSAGE_CONTENT intent.
+    /// </summary>
     GatewayMessageContent = 1 << 18,
 
+    /// <summary>
+    ///     Indicates that the app has enabled the MESSAGE_CONTENT intent on a bot in less than 100 servers.
+    /// </summary>
     GatewayMessageContentLimited = 1 << 19,
 
+    /// <summary>
+    /// 	Indicates if an app has registered global application commands.
+    /// </summary>
     ApplicationCommandBadge = 1 << 23,
 
+    /// <summary>
+    ///     Indicates if an app is considered active.
+    /// </summary>
     ActiveApplication = 1 << 24
 }
-

--- a/src/Discord.Net.Core/Entities/Applications/ApplicationInstallParams.cs
+++ b/src/Discord.Net.Core/Entities/Applications/ApplicationInstallParams.cs
@@ -1,31 +1,26 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Discord
+namespace Discord;
+
+/// <summary>
+///     Represents install parameters for an application.
+/// </summary>
+public class ApplicationInstallParams
 {
     /// <summary>
-    ///     Represents install parameters for an application.
+    ///     Gets the scopes to install this application.
     /// </summary>
-    public class ApplicationInstallParams
+    public IReadOnlyCollection<string> Scopes { get; }
+
+    /// <summary>
+    ///     Gets the default permissions to install this application
+    /// </summary>
+    public GuildPermission Permission { get; }
+
+    public ApplicationInstallParams(string[] scopes, GuildPermission permission)
     {
-        /// <summary>
-        ///     Gets the scopes to install this application.
-        /// </summary>
-        public IReadOnlyCollection<string> Scopes { get; }
-
-        /// <summary>
-        ///     Gets the default permissions to install this application
-        /// </summary>
-        public GuildPermission? Permission { get; }
-
-        internal ApplicationInstallParams(string[] scopes, GuildPermission? permission)
-        {
-            Scopes = scopes.ToImmutableArray();
-            Permission = permission;
-        }
+        Scopes = scopes.ToImmutableArray();
+        Permission = permission;
     }
 }

--- a/src/Discord.Net.Core/Entities/Applications/ApplicationInstallParams.cs
+++ b/src/Discord.Net.Core/Entities/Applications/ApplicationInstallParams.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -20,7 +21,10 @@ public class ApplicationInstallParams
 
     public ApplicationInstallParams(string[] scopes, GuildPermission permission)
     {
-        Scopes = scopes.ToImmutableArray();
+        Preconditions.NotNull(scopes, nameof(scopes));
+        Scopes = scopes
+            .Where(scope => !string.IsNullOrEmpty(scope))
+            .ToImmutableArray();
         Permission = permission;
     }
 }

--- a/src/Discord.Net.Core/Entities/Applications/ApplicationInstallParams.cs
+++ b/src/Discord.Net.Core/Entities/Applications/ApplicationInstallParams.cs
@@ -22,9 +22,11 @@ public class ApplicationInstallParams
     public ApplicationInstallParams(string[] scopes, GuildPermission permission)
     {
         Preconditions.NotNull(scopes, nameof(scopes));
-        Scopes = scopes
-            .Where(scope => !string.IsNullOrEmpty(scope))
-            .ToImmutableArray();
+        foreach (var scope in scopes)
+        {
+            Preconditions.NotNullOrEmpty(scope, nameof(scope));
+        }
+        Scopes = scopes.ToImmutableArray();
         Permission = permission;
     }
 }

--- a/src/Discord.Net.Core/Entities/Applications/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/Applications/IApplication.cs
@@ -24,7 +24,7 @@ namespace Discord
         /// </summary>
         ApplicationFlags Flags { get; }
         /// <summary>
-        ///     Gets a collection of install parameters for this application. <see langword="null"/> if disabled.
+        ///     Gets a collection of install parameters for this application; <see langword="null"/> if disabled.
         /// </summary>
         ApplicationInstallParams? InstallParams { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Applications/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/Applications/IApplication.cs
@@ -24,7 +24,7 @@ namespace Discord
         /// </summary>
         ApplicationFlags Flags { get; }
         /// <summary>
-        ///     Gets a collection of install parameters for this application.
+        ///     Gets a collection of install parameters for this application. <see langword="null"/> if disabled.
         /// </summary>
         ApplicationInstallParams? InstallParams { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Applications/ModifyApplicationProperties.cs
+++ b/src/Discord.Net.Core/Entities/Applications/ModifyApplicationProperties.cs
@@ -29,4 +29,28 @@ public class ModifyApplicationProperties
     ///     Gets or sets the icon of the application.
     /// </summary>
     public Optional<Image?> Icon { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the default rich presence invite cover image of the application.
+    /// </summary>
+    public Optional<Image?> CoverImage { get; set; }
+
+    /// <summary>
+    ///     Gets or set the default custom authorization URL for the app, if enabled.
+    /// </summary>
+    public Optional<string> CustomInstallUrl { get; set; }
+
+    /// <summary>
+    ///     Gets or sets settings for the app's default in-app authorization link, if enabled.
+    /// </summary>
+    public Optional<ApplicationInstallParams> InstallParams { get; set; }
+
+    /// <summary>
+    ///     Gets or sets app's public flags.
+    /// </summary>
+    /// <remarks>
+    ///     Only <see cref="ApplicationFlags.GatewayGuildMembersLimited"/>, <see cref="ApplicationFlags.GatewayMessageContentLimited"/> and
+    ///     <see cref="ApplicationFlags.GatewayPresenceLimited"/> flags can be updated.
+    /// </remarks>
+    public Optional<ApplicationFlags> Flags { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Common/InstallParams.cs
+++ b/src/Discord.Net.Rest/API/Common/InstallParams.cs
@@ -1,18 +1,13 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Discord.API
+namespace Discord.API;
+
+internal class InstallParams
 {
-    internal class InstallParams
-    {
-        [JsonPropertyName("scopes")]
-        public string[] Scopes { get; set; } = Array.Empty<string>();
-        [JsonPropertyName("permissions")]
-        public ulong Permission { get; set; }
-    }
+    [JsonPropertyName("scopes")]
+    public string[] Scopes { get; set; } = Array.Empty<string>();
+    [JsonPropertyName("permissions")]
+    public ulong Permission { get; set; }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyCurrentApplicationBotParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyCurrentApplicationBotParams.cs
@@ -1,22 +1,33 @@
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Discord.API.Rest;
 
 internal class ModifyCurrentApplicationBotParams
 {
-    [JsonPropertyName("interactions_endpoint_url")]
-    public Optional<string> InteractionsEndpointUrl { get; set; }
-
-    [JsonPropertyName("role_connections_verification_url")]
-    public Optional<string> RoleConnectionsEndpointUrl { get; set; }
+    [JsonPropertyName("custom_install_url")]
+    public Optional<string> CustomInstallUrl { get; set; }
 
     [JsonPropertyName("description")]
     public Optional<string> Description { get; set; }
 
-    [JsonPropertyName("tags")]
-    public Optional<string[]> Tags { get; set; }
+    [JsonPropertyName("role_connections_verification_url")]
+    public Optional<string> RoleConnectionsEndpointUrl { get; set; }
+
+    [JsonPropertyName("install_params")]
+    public Optional<InstallParams> InstallParams { get; set; }
+
+    [JsonPropertyName("flags")]
+    public Optional<ApplicationFlags> Flags { get; set; }
 
     [JsonPropertyName("icon")]
     public Optional<Image?> Icon { get; set; }
+
+    [JsonPropertyName("cover_image")]
+    public Optional<Image?> CoverImage { get; set; }
+
+    [JsonPropertyName("interactions_endpoint_url")]
+    public Optional<string> InteractionsEndpointUrl { get; set; }
+
+    [JsonPropertyName("tags")]
+    public Optional<string[]> Tags { get; set; }
 }

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -1,3 +1,4 @@
+using Discord.API;
 using Discord.API.Rest;
 using System;
 using System.Collections.Generic;
@@ -28,9 +29,12 @@ namespace Discord.Rest
             var args = new ModifyApplicationProperties();
             func(args);
 
-            if(args.Tags.IsSpecified)
+            if (args.Tags.IsSpecified)
+            {
+                Preconditions.AtMost(args.Tags.Value.Length, DiscordConfig.MaxApplicationTagCount, nameof(args.Tags), $"An application can have a maximum of {DiscordConfig.MaxApplicationTagCount} applied.");
                 foreach (var tag in args.Tags.Value)
                     Preconditions.AtMost(tag.Length, DiscordConfig.MaxApplicationTagLength, nameof(args.Tags), $"An application tag must have length less or equal to {DiscordConfig.MaxApplicationTagLength}");
+            }
 
             if(args.Description.IsSpecified)
                 Preconditions.AtMost(args.Description.Value.Length, DiscordConfig.MaxApplicationDescriptionLength, nameof(args.Description), $"An application description tag mus have length less or equal to {DiscordConfig.MaxApplicationDescriptionLength}");
@@ -42,6 +46,14 @@ namespace Discord.Rest
                 Icon = args.Icon.IsSpecified ? args.Icon.Value?.ToModel() : Optional<API.Image?>.Unspecified,
                 InteractionsEndpointUrl = args.InteractionsEndpointUrl,
                 RoleConnectionsEndpointUrl = args.RoleConnectionsEndpointUrl,
+                Flags = args.Flags,
+                CoverImage = args.CoverImage.IsSpecified ? args.CoverImage.Value?.ToModel() : Optional<API.Image?>.Unspecified,
+                CustomInstallUrl = args.CustomInstallUrl,
+                InstallParams = args.InstallParams.Map(a => new InstallParams
+                {
+                    Permission = (ulong)args.InstallParams.Value.Permission,
+                    Scopes = args.InstallParams.Value.Scopes.ToArray()
+                })
             }, options);
         }
 

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -61,8 +61,10 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string? InteractionsEndpointUrl { get; private set; }
 
+        /// <inheritdoc />
         public ApplicationInstallParams? InstallParams { get; private set; }
 
+        /// <inheritdoc />
         public IReadOnlyCollection<string> Tags { get; private set; }
 
         internal RestApplication(BaseDiscordClient discord, ulong id)
@@ -92,8 +94,10 @@ namespace Discord.Rest
             Tags = model.Tags.GetValueOrDefault(null)?.ToImmutableArray() ?? ImmutableArray<string>.Empty;
             PrivacyPolicy = model.PrivacyPolicy;
             TermsOfService = model.TermsOfService;
-            var installParams = model.InstallParams.GetValueOrDefault(null);
-            InstallParams = new ApplicationInstallParams(installParams?.Scopes ?? Array.Empty<string>(), (GuildPermission?)installParams?.Permission);
+
+            InstallParams = model.InstallParams
+                .Map(p => new ApplicationInstallParams(p.Scopes, (GuildPermission)p.Permission))
+                .GetValueOrDefault(null);
 
             if (model.Flags.IsSpecified)
                 Flags = model.Flags.Value;


### PR DESCRIPTION
Mirror of https://github.com/discord-net/Discord.Net/pull/2730

[Docs PR](https://github.com/discord/discord-api-docs/pull/6297)

This PR adds some newly documented features for `Edit Current Application` endpoint.
### Changes
- Add new editable properties
- Add some missing xmldocs
- Make the constructor of `ApplicationInstallParams` public, so it can be used to modify the app
- `ApplicationInstallParams.Permission` is not nullable
